### PR TITLE
Add missing framework to podspec. Add UIColor utils.

### DIFF
--- a/CKUITools.podspec
+++ b/CKUITools.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/genericspecific/CKUITools.git", :tag => "v0.5.2" }
   s.platform     = :ios
   s.source_files = '*.{h,m,c}'
+  s.frameworks   = 'QuartzCore'
   s.requires_arc = true
 end

--- a/UIColor+CKUITools.h
+++ b/UIColor+CKUITools.h
@@ -1,0 +1,18 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface UIColor (CKUITools)
+
+/**
+* Returns a UIColor from the given hex representation. Example: [UIColor colorWithHexRGB:0x3b789b]
+*/
++ (UIColor*)colorWithHexRGB:(NSUInteger)rgb;
+
++ (UIColor*)colorWithHexRGB:(NSUInteger)rgb alpha:(CGFloat)alpha;
+
+@end

--- a/UIColor+CKUITools.m
+++ b/UIColor+CKUITools.m
@@ -1,0 +1,24 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "UIColor+CKUITools.h"
+
+
+@implementation UIColor (CKUITools)
+
++ (UIColor*)colorWithHexRGB:(NSUInteger)rgbValue
+{
+    return [UIColor colorWithRed:((CGFloat) ((rgbValue & 0xFF0000) >> 16)) / 255.0 green:((CGFloat) ((rgbValue & 0xFF00) >> 8)) / 255.0
+        blue:((CGFloat) (rgbValue & 0xFF)) / 255.0 alpha:1.0];
+}
+
++ (UIColor*)colorWithHexRGB:(NSUInteger)rgbValue alpha:(CGFloat)alpha
+{
+    return [UIColor colorWithRed:((CGFloat) ((rgbValue & 0xFF0000) >> 16)) / 255.0 green:((CGFloat) ((rgbValue & 0xFF00) >> 8)) / 255.0
+        blue:((CGFloat) (rgbValue & 0xFF)) / 255.0 alpha:alpha];
+}
+
+@end


### PR DESCRIPTION
- Add missing framework to Podspec
- Add UIColor utils - initially just two category methods to convert from web colors. 
